### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/MarcoIeni/marco-crate-example/compare/v0.1.2...v0.1.3) - 2023-04-21
+
+### Other
+- wip
+
 ## [0.1.2](https://github.com/MarcoIeni/marco-crate-example/compare/v0.1.1...v0.1.2) - 2023-04-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "marco-crate-example"
-version = "0.1.2"
+version = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-crate-example"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "test for release-plz"
 repository = "https://github.com/MarcoIeni/marco-crate-example"


### PR DESCRIPTION
## 🤖 New release
* `marco-crate-example`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/MarcoIeni/marco-crate-example/compare/v0.1.2...v0.1.3) - 2023-04-21

### Other
- wip
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).