### PR TITLE
chore: release v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/MarcoIeni/marco-crate-example/compare/v0.1.14...v0.1.15) - 2023-10-15
+
+### Other
+- Update release-plz.yml
+- Update README.md
+- Update README.md
+- Update README.md
+
 ## [0.1.14](https://github.com/MarcoIeni/marco-crate-example/compare/v0.1.13...v0.1.14) - 2023-09-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "marco-crate-example"
-version = "0.1.14"
+version = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-crate-example"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "test for release-plz"
 repository = "https://github.com/MarcoIeni/marco-crate-example"


### PR DESCRIPTION
## 🤖 New release
* `marco-crate-example`: 0.1.14 -> 0.1.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.15](https://github.com/MarcoIeni/marco-crate-example/compare/v0.1.14...v0.1.15) - 2023-10-15

### Other
- Update release-plz.yml
- Update README.md
- Update README.md
- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).